### PR TITLE
zenoss core 4, seems to have trouble when there is more than 2 fields separated by "|" (pipe...

### DIFF
--- a/ZenPacks/Nagios/CheckPing/objects/objects.xml
+++ b/ZenPacks/Nagios/CheckPing/objects/objects.xml
@@ -20,7 +20,7 @@ True
 3
 </property>
 <property type="string" id="commandTemplate" mode="w" >
-check_ping -H $devname -w 180,100% -c 300,100% | sed -e 's# - Packet loss#|LOSS#;s#%,##;s#ms##;s# = #=#g'
+check_ping -H $devname -w 180,100% -c 300,100% | sed -e 's# - Packet loss#|LOSS#;s#%,##;s#ms##;s# = #=#g;s#|rta=.*$$##'
 </property>
 <property type="int" id="cycletime" mode="w" >
 300


### PR DESCRIPTION
...s) in the command output

so filter the third one

before:
/opt/zenoss/libexec/check_ping -H 8.8.8.8 -w 180,100% -c 300,100% | sed -e 's# - Packet loss#|LOSS#;s#%,##;s#ms##;s# = #=#g'
PING OK|LOSS=0 RTA=31.38 |rta=31.384001ms;180.000000;300.000000;0.000000 pl=0%;100;100;0

after:
/opt/zenoss/libexec/check_ping -H 8.8.8.8 -w 180,100% -c 300,100% | sed -e 's# - Packet loss#|LOSS#;s#%,##;s#ms##;s# = #=#g;s#|rta=.*$##'
PING OK|LOSS=0 RTA=31.44

p.s. the used '$' has to be repeated, elsewhere the zenoss command parser cannot escape it properly
